### PR TITLE
Add builds for busybox containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Log into GiHub Container Registry
         run: docker login -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}" ghcr.io
-      - name: Build container
+      - name: Build (scratch) container
         run: 'docker build -t ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }} .'
-      - name: Push container
-        run: 'docker push ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}'
+      - name: Build (busybox) container
+        run: 'docker build --build-arg BASE_IMAGE=busybox:musl -t ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}-busybox .'
+      - name: Push containers
+        run: 'docker push --all-tags ghcr.io/${{ github.repository }}'
       - name: Tag container as dev
         if: github.ref_name == 'master'
         run: |-
           docker tag ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }} ghcr.io/${{ github.repository }}:dev
-          docker push ghcr.io/${{ github.repository }}:dev
+          docker tag ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}-busybox ghcr.io/${{ github.repository }}:dev-busybox
+          docker push --all-tags ghcr.io/${{ github.repository }}
   build_executables:
     runs-on: ubuntu-latest
     container: 'golang:1.19-alpine'


### PR DESCRIPTION
* Allows for debugging and some minimal (but highly useful) commands to exist in the built container.
  * Very useful if debugging inside the container is required
  * Useful to the exec discovery method in the built docker container. May still be more basic things desired in an image such as regular "bash", "curl", "jq", etc, but such an image (alpine maybe) can come later.
* Pushes all tagged containers to the registry. (Same when re-tagging dev)